### PR TITLE
fix(template): remove stray dot before HTML comment in skills template

### DIFF
--- a/src/app/pages/skills/skills.component.html
+++ b/src/app/pages/skills/skills.component.html
@@ -1,4 +1,4 @@
-.<!-- ======= Skills Section ======= -->
+<!-- ======= Skills Section ======= -->
 <section id="skills" class="skills section-bg">
   <div class="container" data-aos="fade-up">
 


### PR DESCRIPTION
## Cambios incluidos

- Eliminado el punto `.` suelto al inicio de `skills.component.html`  
- El archivo comenzaba con `.<!-- ======= Skills Section... -->` lo que hacía que el punto se renderizara como texto visible en la página