### PR TITLE
fix(deps): align @angular-devkit/build-angular and @angular/cli with Angular 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "zone.js": "~0.14.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^21.1.3",
-    "@angular/cli": "~21.1.0",
+    "@angular-devkit/build-angular": "^18.2.6",
+    "@angular/cli": "^18.2.6",
     "@angular/compiler-cli": "^18.2.6",
     "@types/jasmine": "~5.1.4",
     "jasmine-core": "~5.3.0",


### PR DESCRIPTION
## Problema

El CI falla con `ERESOLVE` porque:
- `@angular-devkit/build-angular@21.1.3` requiere `@angular/compiler-cli@^21.0.0`  
- Pero el proyecto tiene `@angular/compiler-cli@^18.2.6`  

Esto ocurrió porque Dependabot bumpeó `@angular-devkit/build-angular` a `^21.1.3` (Angular 21) mientras el resto del framework es `^18.2.6`  

## Fix

Downgrade de ambos paquetes a `^18.2.6` para alinearlos con todo el ecosistema Angular 18:
- `@angular-devkit/build-angular`: `^21.1.3` → `^18.2.6`  
- `@angular/cli`: `~21.1.0` → `^18.2.6`