### PR TITLE
feat(skills): populate skills section with 10 technical skills and fi…

### DIFF
--- a/src/app/pages/skills/skills.component.html
+++ b/src/app/pages/skills/skills.component.html
@@ -8,8 +8,18 @@
     </div>
 
     <div class="row skills-content">
-      <div class="col-lg-6" *ngFor="let item of _about.about.skills?.skill">
-        <div class="progress">
+      <div class="col-lg-6">
+        <div class="progress" *ngFor="let item of _about.about.skills?.skill | slice:0:5">
+          <span class="skill">{{ item.skill }}<em class="val">{{ item.porcentaje }}</em></span>
+          <div class="progress">
+            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
+              [attr.aria-label]="item.skill" [style.width]="item.porcentaje"
+              [attr.aria-valuenow]="item.porcentaje" aria-valuemin="0" aria-valuemax="100"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="progress" *ngFor="let item of _about.about.skills?.skill | slice:5:10">
           <span class="skill">{{ item.skill }}<em class="val">{{ item.porcentaje }}</em></span>
           <div class="progress">
             <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"


### PR DESCRIPTION
…x layout

- Add 10 technical skills with percentages to about.json (embedded in AboutService data)
- Fix skills template to properly split skills into two columns using SlicePipe:
  - Column 1: skills 1-5 (IBM i, PHP, JS/TS/Angular, Node.js, Oracle PL/SQL)
  - Column 2: skills 6-10 (Git/DevOps, Docker/K8s, Vue/React, UiPath, C#/.NET)
- Skills data sourced from CV technical skills section