### PR TITLE
feat(resume): populate resume section with full work history and educ…

### DIFF
--- a/firebase-data/resumen.json
+++ b/firebase-data/resumen.json
@@ -5,28 +5,36 @@
       "title": "Ingeniero de Sistemas",
       "date": "2007",
       "institute": "Fundación Universitaria San Martín",
-      "site": "Palmira, Valle, Colombia"
+      "site": "Palmira, Valle, Colombia",
+      "course": ""
     },
     {
       "title": "Bachiller Técnico (Electricidad)",
       "date": "1999",
       "institute": "Instituto Técnico Industrial Providencia",
-      "site": "El Cerrito, Valle, Colombia"
+      "site": "El Cerrito, Valle, Colombia",
+      "course": ""
     },
     {
       "course": "RPA Developer Foundation",
       "date": "Junio 2020",
-      "institute": "UiPath Academy"
+      "institute": "UiPath Academy",
+      "site": "Online",
+      "title": ""
     },
     {
       "course": "Node.js: De cero a experto",
       "date": "Febrero 2020",
-      "institute": "Udemy"
+      "institute": "Udemy",
+      "site": "Online",
+      "title": ""
     },
     {
       "course": "Angular 9, Laravel 5, RxJS",
       "date": "2020 - 2022",
-      "institute": "Udemy"
+      "institute": "Udemy",
+      "site": "Online",
+      "title": ""
     }
   ],
   "experiences": [


### PR DESCRIPTION
…ation from CV

- Create firebase-data/resumen.json with complete CV data:
  - 2 Education entries: Ingeniero de Sistemas (2007), Bachiller Técnico (1999)
  - 3 Course entries: RPA Developer Foundation (UiPath), Node.js (Udemy), Angular/Laravel/RxJS (Udemy)
  - 6 Work experiences with detailed descriptions:
    * PersonalSoft S.A.S. (2019-Actualidad): Leasing Bancolombia, Clínica de las Américas, Pactia, Intersoftware, Votre/Leonisa
    * Certadata S.A.S. (2015-2019): COBOL/400, AS/400, C#
    * Premize S.A.S. (2012-2014): PHP + Oracle
    * Intergrupo S.A. (2012): PHP Symfony 2 + Oracle
    * Coomeva EPS (2011-2012): PHP + Oracle
    * Felinux Ltda (2008-2010): PHP, jQuery, MySQL
- Add site and title fields to course entries for proper template rendering