### PR TITLE
fix(about): use static local profile image instead of Firebase dynami…

### DIFF
--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -9,7 +9,7 @@
 
     <div class="row">
       <div class="col-lg-4">
-        <img src="{{ _about.about.imagen }}" class="img-fluid" alt="" />
+        <img src="../assets/img/profile-img.jpg" class="img-fluid" alt="" />
       </div>
       <div class="col-lg-8 pt-4 pt-lg-0 content">
         <h3>{{ _about.about.titulo }}</h3>


### PR DESCRIPTION
…c URL

The profile image should be served from local assets for faster loading and to avoid depending on Firebase Storage.

- Change image src from {{ _about.about.imagen }} (Firebase dynamic URL) to static path ../assets/img/profile-img.jpg (local asset)
- The profile-img.jpg already exists in src/assets/img/
- Remove imagen field dependency from about.json since it's now hardcoded