### PR TITLE
feat: migrate to standalone components and fix build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -11,12 +11,12 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": "dist/",
             "index": "src/index.html",
-            "main": "src/main.ts",
-            "polyfills": "src/polyfills.ts",
+            "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
@@ -47,16 +47,11 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ],
-              "sourceMap": true,
               "outputHashing": "all"
             },
             "development": {
-              "buildOptimizer": false,
               "optimization": false,
-              "vendorChunk": true,
-              "extractLicenses": false,
-              "sourceMap": true,
-              "namedChunks": true
+              "sourceMap": true
             }
           },
           "defaultConfiguration": "production"
@@ -65,10 +60,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "ediervillaneda.github.io:build:production"
+              "buildTarget": "ediervillaneda.github.io:build:production"
             },
             "development": {
-              "browserTarget": "ediervillaneda.github.io:build:development"
+              "buildTarget": "ediervillaneda.github.io:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -76,7 +71,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "ediervillaneda.github.io:build"
+            "buildTarget": "ediervillaneda.github.io:build"
           }
         },
         "test": {

--- a/angular.json
+++ b/angular.json
@@ -23,17 +23,36 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.css",
+              "src/assets/vendor/bootstrap/css/bootstrap.min.css",
+              "src/assets/vendor/icofont/icofont.min.css",
+              "src/assets/vendor/boxicons/css/boxicons.min.css",
+              "src/assets/vendor/venobox/venobox.min.css",
+              "src/assets/vendor/owl.carousel/assets/owl.carousel.min.css",
+              "src/assets/vendor/aos/aos.css",
+              "src/assets/css/style.css"
             ],
-            "scripts": []
+            "scripts": [
+              "src/assets/vendor/jquery/jquery.min.js",
+              "src/assets/vendor/bootstrap/js/bootstrap.bundle.min.js",
+              "src/assets/vendor/jquery.easing/jquery.easing.min.js",
+              "src/assets/vendor/php-email-form/validate.js",
+              "src/assets/vendor/waypoints/jquery.waypoints.min.js",
+              "src/assets/vendor/counterup/counterup.min.js",
+              "src/assets/vendor/isotope-layout/isotope.pkgd.min.js",
+              "src/assets/vendor/venobox/venobox.min.js",
+              "src/assets/vendor/owl.carousel/owl.carousel.min.js",
+              "src/assets/vendor/aos/aos.js",
+              "src/assets/js/main.js"
+            ]
           },
           "configurations": {
             "production": {
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "1024kb",
-                  "maximumError": "2mb"
+                  "maximumWarning": "3mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "karma-coverage": "~2.2.1",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
-        "typescript": "~6.0.3"
+        "typescript": "~5.9.3"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -14186,9 +14186,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "karma-coverage": "~2.2.1",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
-    "typescript": "~6.0.3"
+    "typescript": "~5.9.3"
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,11 +2,36 @@ import { Component } from '@angular/core';
 import { AboutService } from './services/about.service';
 import { HeroService } from './services/hero.service';
 import { SocialService } from './services/social.service';
+import { HeaderComponent } from './share/header/header.component';
+import { HeroComponent } from './share/hero/hero.component';
+import { AboutComponent } from './pages/about/about.component';
+import { FactsComponent } from './pages/facts/facts.component';
+import { SkillsComponent } from './pages/skills/skills.component';
+import { ResumeComponent } from './pages/resume/resume.component';
+import { PortfolioComponent } from './pages/portfolio/portfolio.component';
+import { ServicesComponent } from './pages/services/services.component';
+import { ReferencesComponent } from './pages/references/references.component';
+import { ContactComponent } from './pages/contact/contact.component';
+import { FooterComponent } from './share/footer/footer.component';
 
 @Component({
+  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
+  imports: [
+    HeaderComponent,
+    HeroComponent,
+    AboutComponent,
+    FactsComponent,
+    SkillsComponent,
+    ResumeComponent,
+    PortfolioComponent,
+    ServicesComponent,
+    ReferencesComponent,
+    ContactComponent,
+    FooterComponent,
+  ],
 })
 export class AppComponent {
   title = 'ediervillaneda.github.io';

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,0 +1,11 @@
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter, withHashLocation } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes, withHashLocation()),
+    provideHttpClient(),
+  ],
+};

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,11 @@
-import { ApplicationConfig } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withHashLocation } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes, withHashLocation()),
     provideHttpClient(),
   ],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,0 +1,13 @@
+import { Routes } from '@angular/router';
+import { PortfolioComponent } from './pages/portfolio/portfolio.component';
+import { AboutComponent } from './pages/about/about.component';
+import { ContactComponent } from './pages/contact/contact.component';
+import { ResumeComponent } from './pages/resume/resume.component';
+
+export const routes: Routes = [
+  { path: 'home', component: PortfolioComponent },
+  { path: 'about', component: AboutComponent },
+  { path: 'contact', component: ContactComponent },
+  { path: 'resume', component: ResumeComponent },
+  { path: '**', pathMatch: 'full', redirectTo: 'home' },
+];

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -1,9 +1,12 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { AboutService } from '../../services/about.service';
 
 @Component({
+  standalone: true,
   selector: 'app-about',
   templateUrl: './about.component.html',
+  imports: [CommonModule],
 })
 export class AboutComponent implements OnInit {
   constructor(public _about: AboutService) {}

--- a/src/app/pages/contact/contact.component.ts
+++ b/src/app/pages/contact/contact.component.ts
@@ -1,14 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
+  standalone: true,
   selector: 'app-contact',
   templateUrl: './contact.component.html',
 })
 export class ContactComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }

--- a/src/app/pages/facts/facts.component.html
+++ b/src/app/pages/facts/facts.component.html
@@ -9,7 +9,7 @@
 
     <div class="row">
 
-      <div class="col-6 col-sm-3" *ngFor="let item of _facts.facts?.fact">
+      <div class="col-6 col-sm-3" *ngFor="let item of _facts.facts.fact">
         <div class="count-box">
           <!-- Condicional para mostrar el icono solo si existe -->
           <fa-icon *ngIf="item.icono" [icon]="['fas', item.icono]"></fa-icon>

--- a/src/app/pages/facts/facts.component.ts
+++ b/src/app/pages/facts/facts.component.ts
@@ -1,20 +1,20 @@
 import { Component, OnInit } from '@angular/core';
-import { FactsService } from '../../services/facts.service';
+import { CommonModule } from '@angular/common';
+import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
-
-import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { FactsService } from '../../services/facts.service';
 
 @Component({
+  standalone: true,
   selector: 'app-facts',
   templateUrl: './facts.component.html',
+  imports: [CommonModule, FontAwesomeModule],
 })
 export class FactsComponent implements OnInit {
   constructor(public _facts: FactsService, public library: FaIconLibrary) {
     library.addIconPacks(fas, far);
   }
 
-  ngOnInit(): void {
-    /* TODO document why this method 'ngOnInit' is empty */
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/pages/portfolio/portfolio.component.ts
+++ b/src/app/pages/portfolio/portfolio.component.ts
@@ -1,14 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
+  standalone: true,
   selector: 'app-portfolio',
   templateUrl: './portfolio.component.html',
 })
 export class PortfolioComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }

--- a/src/app/pages/references/references.component.ts
+++ b/src/app/pages/references/references.component.ts
@@ -1,11 +1,10 @@
 import { Component } from '@angular/core';
 
 @Component({
+  standalone: true,
   selector: 'app-references',
   templateUrl: './references.component.html',
 })
 export class ReferencesComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/src/app/pages/resume/resume.component.ts
+++ b/src/app/pages/resume/resume.component.ts
@@ -1,9 +1,12 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { ResumeService } from 'src/app/services/resume.service';
 
 @Component({
+  standalone: true,
   selector: 'app-resume',
   templateUrl: './resume.component.html',
+  imports: [CommonModule],
 })
 export class ResumeComponent implements OnInit {
   constructor(public _resume: ResumeService) {}

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -1,14 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
+  standalone: true,
   selector: 'app-services',
   templateUrl: './services.component.html',
 })
 export class ServicesComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }

--- a/src/app/pages/skills/skills.component.ts
+++ b/src/app/pages/skills/skills.component.ts
@@ -1,15 +1,15 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { AboutService } from 'src/app/services/about.service';
 
 @Component({
+  standalone: true,
   selector: 'app-skills',
   templateUrl: './skills.component.html',
+  imports: [CommonModule],
 })
 export class SkillsComponent implements OnInit {
   constructor(public _about: AboutService) {}
 
-  ngOnInit(): void {
-    // TODO document why this method 'ngOnInit' is empty
-
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/services/about.service.ts
+++ b/src/app/services/about.service.ts
@@ -30,7 +30,7 @@ export class AboutService {
           this.about.age = this.calcularEdad(date);
           resolve();
         },
-        error: (err) => {
+        error: (err: unknown) => {
           this.cargando = false;
           reject(err);
         },

--- a/src/app/services/facts.service.ts
+++ b/src/app/services/facts.service.ts
@@ -24,7 +24,7 @@ export class FactsService {
           this.cargando = false;
           resolve();
         },
-        error: (err) => {
+        error: (err: unknown) => {
           this.cargando = false;
           reject(err);
         },

--- a/src/app/services/hero.service.ts
+++ b/src/app/services/hero.service.ts
@@ -23,7 +23,7 @@ export class HeroService {
           this.cargando = false;
           resolve();
         },
-        error: (err) => {
+        error: (err: unknown) => {
           this.cargando = false;
           reject(err);
         },

--- a/src/app/services/resume.service.ts
+++ b/src/app/services/resume.service.ts
@@ -26,7 +26,7 @@ export class ResumeService {
           this.cargando = false;
           resolve();
         },
-        error: (err) => {
+        error: (err: unknown) => {
           this.cargando = false;
           reject(err);
         },

--- a/src/app/services/social.service.ts
+++ b/src/app/services/social.service.ts
@@ -26,7 +26,7 @@ export class SocialService {
           this.cargando = false;
           resolve();
         },
-        error: (err) => {
+        error: (err: unknown) => {
           this.cargando = false;
           reject(err);
         },

--- a/src/app/share/footer/footer.component.ts
+++ b/src/app/share/footer/footer.component.ts
@@ -1,14 +1,17 @@
 import { Component, OnInit } from '@angular/core';
-import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { CommonModule } from '@angular/common';
+import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { fab } from '@fortawesome/free-brands-svg-icons';
 import { AboutService } from '../../services/about.service';
 import { HeroService } from '../../services/hero.service';
 import { SocialService } from '../../services/social.service';
 
 @Component({
+  standalone: true,
   selector: 'app-footer',
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.css'],
+  imports: [CommonModule, FontAwesomeModule],
 })
 export class FooterComponent implements OnInit {
   constructor(
@@ -20,7 +23,5 @@ export class FooterComponent implements OnInit {
     library.addIconPacks(fab);
   }
 
-  ngOnInit(): void {
-    // TODO document why this method 'ngOnInit' is empty
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/share/header/header.component.ts
+++ b/src/app/share/header/header.component.ts
@@ -1,16 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
+  standalone: true,
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css'],
 })
 export class HeaderComponent implements OnInit {
-  constructor() {
-    /* TODO document why this constructor is empty */
-  }
+  constructor() {}
 
-  ngOnInit(): void {
-    /* TODO document why this method 'ngOnInit' is empty */
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/share/hero/hero.component.ts
+++ b/src/app/share/hero/hero.component.ts
@@ -1,14 +1,17 @@
 import { Component, OnInit } from '@angular/core';
-import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { CommonModule } from '@angular/common';
+import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { fab } from '@fortawesome/free-brands-svg-icons';
 import { AboutService } from '../../services/about.service';
 import { HeroService } from '../../services/hero.service';
 import { SocialService } from 'src/app/services/social.service';
 
 @Component({
+  standalone: true,
   selector: 'app-hero',
   templateUrl: './hero.component.html',
   styleUrls: ['./hero.component.css'],
+  imports: [CommonModule, FontAwesomeModule],
 })
 export class HeroComponent implements OnInit {
   constructor(
@@ -20,7 +23,5 @@ export class HeroComponent implements OnInit {
     library.addIconPacks(fab);
   }
 
-  ngOnInit(): void {
-    /* TODO document why this method 'ngOnInit' is empty */
-  }
+  ngOnInit(): void {}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -21,17 +21,6 @@
   <link
     href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i"
     rel="stylesheet">
-
-  <!-- Vendor CSS Files -->
-  <link href="./assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-  <link href="./assets/vendor/icofont/icofont.min.css" rel="stylesheet">
-  <link href="./assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
-  <link href="./assets/vendor/venobox/venobox.css" rel="stylesheet">
-  <link href="./assets/vendor/owl.carousel/assets/owl.carousel.min.css" rel="stylesheet">
-  <link href="./assets/vendor/aos/aos.css" rel="stylesheet">
-
-  <!-- Template Main CSS File -->
-  <link href="./assets/css/style.css" rel="stylesheet">
 </head>
 
 <body>
@@ -41,21 +30,6 @@
 
   <a href="#" class="back-to-top"><em class="bx bx-up-arrow-alt"></em></a>
   <div id="preloader"></div>
-
-  <!-- Vendor JS Files -->
-  <script src="./assets/vendor/jquery/jquery.min.js"></script>
-  <script src="./assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="./assets/vendor/jquery.easing/jquery.easing.min.js"></script>
-  <script src="./assets/vendor/php-email-form/validate.js"></script>
-  <script src="./assets/vendor/waypoints/jquery.waypoints.min.js"></script>
-  <script src="./assets/vendor/counterup/counterup.min.js"></script>
-  <script src="./assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
-  <script src="./assets/vendor/venobox/venobox.min.js"></script>
-  <script src="./assets/vendor/owl.carousel/owl.carousel.min.js"></script>
-  <script src="./assets/vendor/aos/aos.js"></script>
-
-  <!-- Template Main JS File -->
-  <script src="./assets/js/main.js"></script>
 </body>
 
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,5 @@
-import { enableProdMode } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
 
-import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
-
-if (environment.production) {
-  enableProdMode();
-}
-
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch(err => console.error(err));

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,8 +7,7 @@
     "types": []
   },
   "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
+    "src/main.ts"
   ],
   "include": [
     "src/**/*.d.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "es2022",
     "module": "es2022",


### PR DESCRIPTION
## Summary
- Convierte todos los componentes a `standalone: true` con imports explícitos
- Reemplaza `AppModule`/`AppRoutingModule` con `bootstrapApplication`, `app.config.ts`, `app.routes.ts`
- Cambia builder de `browser` a `application` (esbuild)
- Actualiza `tsconfig moduleResolution` a `bundler` (requerido para package exports de Angular 21)
- Baja TypeScript a `~5.9.3` (límite real de `@angular-devkit/build-angular@21`)
- Corrige tipos implícitos `any` en callbacks de servicios
- Agrega `provideZoneChangeDetection()` — requerido en Angular 19+ standalone para CD automático
- Mueve vendor CSS/JS de `index.html` a `angular.json` styles/scripts
- Corrige optional chain innecesaria en facts template (NG8107)
- Aumenta budget inicial a 3mb/5mb (FontAwesome packs completos)

## Test plan
- [x] `npm run build` sin errores ni warnings
- [x] `npm start` — datos cargan correctamente desde Firebase
- [x] Change detection funciona automáticamente (zone.js + provideZoneChangeDetection)