### PR TITLE
feat(portfolio): soften card colors and translate UI to Spanish

### DIFF
--- a/src/app/pages/portfolio/portfolio.component.html
+++ b/src/app/pages/portfolio/portfolio.component.html
@@ -3,14 +3,14 @@
   <div class="container" data-aos="fade-up">
 
     <div class="section-title">
-      <h2>Portfolio</h2>
+      <h2>Portafolio</h2>
       <p>Proyectos desarrollados en sectores financiero, salud y corporativo, abarcando múltiples tecnologías y plataformas.</p>
     </div>
 
     <div class="row">
       <div class="col-lg-12 d-flex justify-content-center" data-aos="fade-up" data-aos-delay="100">
         <ul id="portfolio-flters">
-          <li data-filter="*" class="filter-active">All</li>
+          <li data-filter="*" class="filter-active">Todos</li>
           <li data-filter=".filter-app">Mainframe</li>
           <li data-filter=".filter-card">Financiero</li>
           <li data-filter=".filter-web">Web</li>
@@ -20,161 +20,179 @@
 
     <div class="row portfolio-container" data-aos="fade-up" data-aos-delay="200">
 
+      <!-- Leasing Bancolombia — Mainframe -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-app mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-secondary">Mainframe</span>
-            <small class="text-white-50">IBMi</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#4a5568; color:#e2e8f0;">
+            <span class="badge" style="background-color:#718096; color:#e2e8f0;">Mainframe</span>
+            <small style="color:#a0aec0;">IBMi</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Leasing Bancolombia</h5>
             <p class="card-text text-muted">Sistema de gestión de leasing financiero sobre plataforma IBMi para uno de los principales bancos de Colombia.</p>
             <div class="mt-2">
-              <span class="badge bg-dark me-1">IBMi</span>
-              <span class="badge bg-secondary me-1">RPG ILE</span>
-              <span class="badge bg-secondary">COBOL</span>
+              <span class="badge me-1" style="background-color:#4a5568; color:#e2e8f0;">IBMi</span>
+              <span class="badge me-1" style="background-color:#718096; color:#e2e8f0;">RPG ILE</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">COBOL</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Clínica de las Américas — Web / Salud -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-web mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-primary">Web</span>
-            <small class="text-white-50">Salud</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3a6186; color:#dce8f5;">
+            <span class="badge" style="background-color:#dce8f5; color:#3a6186;">Web</span>
+            <small style="color:#a8c8e8;">Salud</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Clínica de las Américas</h5>
             <p class="card-text text-muted">Plataforma de gestión de citas y expedientes médicos para clínica de alta complejidad en Medellín.</p>
             <div class="mt-2">
-              <span class="badge bg-primary me-1">PHP</span>
-              <span class="badge bg-success me-1">Node.js</span>
-              <span class="badge bg-secondary">MySQL</span>
+              <span class="badge me-1" style="background-color:#3a6186; color:#dce8f5;">PHP</span>
+              <span class="badge me-1" style="background-color:#4a7c59; color:#d8f0e0;">Node.js</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">MySQL</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Pactia Portal Corporativo — Financiero / DevOps -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-card mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-success">Financiero</span>
-            <small class="text-white-50">DevOps</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3d7a5e; color:#d8f0e4;">
+            <span class="badge" style="background-color:#d8f0e4; color:#3d7a5e;">Financiero</span>
+            <small style="color:#a3d4b8;">DevOps</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Pactia Portal Corporativo</h5>
             <p class="card-text text-muted">Portal corporativo para gestión de activos inmobiliarios con integración a pipelines CI/CD en Azure.</p>
             <div class="mt-2">
-              <span class="badge bg-info me-1">Azure DevOps</span>
-              <span class="badge bg-primary me-1">Angular</span>
-              <span class="badge bg-secondary">.NET</span>
+              <span class="badge me-1" style="background-color:#4a8fa8; color:#daf0f8;">Azure DevOps</span>
+              <span class="badge me-1" style="background-color:#3a6186; color:#dce8f5;">Angular</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">.NET</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Votre / Leonisa — Mainframe -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-app mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-secondary">Mainframe</span>
-            <small class="text-white-50">IBMi</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#4a5568; color:#e2e8f0;">
+            <span class="badge" style="background-color:#718096; color:#e2e8f0;">Mainframe</span>
+            <small style="color:#a0aec0;">IBMi</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Votre / Leonisa</h5>
             <p class="card-text text-muted">Módulos de producción, inventario y distribución para empresa líder de moda en Latinoamérica sobre AS/400.</p>
             <div class="mt-2">
-              <span class="badge bg-dark me-1">IBMi</span>
-              <span class="badge bg-secondary">RPG ILE</span>
+              <span class="badge me-1" style="background-color:#4a5568; color:#e2e8f0;">IBMi</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">RPG ILE</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Intersoftware Bioseguridad — Web / Salud -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-web mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-primary">Web</span>
-            <small class="text-white-50">Salud</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3a6186; color:#dce8f5;">
+            <span class="badge" style="background-color:#dce8f5; color:#3a6186;">Web</span>
+            <small style="color:#a8c8e8;">Salud</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Intersoftware Bioseguridad</h5>
             <p class="card-text text-muted">Sistema de control de bioseguridad y seguimiento de protocolos sanitarios en instituciones de salud.</p>
             <div class="mt-2">
-              <span class="badge bg-primary me-1">PHP</span>
-              <span class="badge bg-warning text-dark me-1">jQuery</span>
-              <span class="badge bg-secondary">MySQL</span>
+              <span class="badge me-1" style="background-color:#3a6186; color:#dce8f5;">PHP</span>
+              <span class="badge me-1" style="background-color:#9a7c2e; color:#fef3c7;">jQuery</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">MySQL</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Certadata AS/400 — Financiero -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-card mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-success">Financiero</span>
-            <small class="text-white-50">AS/400</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3d7a5e; color:#d8f0e4;">
+            <span class="badge" style="background-color:#d8f0e4; color:#3d7a5e;">Financiero</span>
+            <small style="color:#a3d4b8;">AS/400</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Certadata AS/400</h5>
             <p class="card-text text-muted">Desarrollo y mantenimiento de módulos financieros y contables sobre plataforma AS/400 para sector bancario.</p>
             <div class="mt-2">
-              <span class="badge bg-dark me-1">COBOL/400</span>
-              <span class="badge bg-secondary">IBMi</span>
+              <span class="badge me-1" style="background-color:#4a5568; color:#e2e8f0;">COBOL/400</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">IBMi</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Premize PHP + Oracle — Web / Corporativo -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-web mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-primary">Web</span>
-            <small class="text-white-50">Corporativo</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3a6186; color:#dce8f5;">
+            <span class="badge" style="background-color:#dce8f5; color:#3a6186;">Web</span>
+            <small style="color:#a8c8e8;">Corporativo</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Premize PHP + Oracle</h5>
             <p class="card-text text-muted">Plataforma de gestión de incentivos y comisiones para fuerza de ventas con backend Oracle y PHP Symfony.</p>
             <div class="mt-2">
-              <span class="badge bg-primary me-1">PHP</span>
-              <span class="badge bg-danger me-1">Oracle</span>
-              <span class="badge bg-secondary">Symfony</span>
+              <span class="badge me-1" style="background-color:#3a6186; color:#dce8f5;">PHP</span>
+              <span class="badge me-1" style="background-color:#8b3a3a; color:#fde8e8;">Oracle</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">Symfony</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Coomeva EPS — Financiero / Salud -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-card mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-success">Financiero</span>
-            <small class="text-white-50">Salud</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3d7a5e; color:#d8f0e4;">
+            <span class="badge" style="background-color:#d8f0e4; color:#3d7a5e;">Financiero</span>
+            <small style="color:#a3d4b8;">Salud</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Coomeva EPS</h5>
             <p class="card-text text-muted">Sistema de autorización de procedimientos médicos y gestión de afiliados para cooperativa de salud.</p>
             <div class="mt-2">
-              <span class="badge bg-primary me-1">PHP</span>
-              <span class="badge bg-danger me-1">Oracle</span>
-              <span class="badge bg-secondary">Laravel</span>
+              <span class="badge me-1" style="background-color:#3a6186; color:#dce8f5;">PHP</span>
+              <span class="badge me-1" style="background-color:#8b3a3a; color:#fde8e8;">Oracle</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">Laravel</span>
             </div>
           </div>
         </div>
       </div>
 
+      <!-- Felinux Plataforma PANCE — Web / Educación -->
       <div class="col-lg-4 col-md-6 portfolio-item filter-web mb-4">
         <div class="card h-100 shadow-sm border-0">
-          <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-            <span class="badge bg-light text-primary">Web</span>
-            <small class="text-white-50">Educación</small>
+          <div class="card-header d-flex justify-content-between align-items-center"
+               style="background-color:#3a6186; color:#dce8f5;">
+            <span class="badge" style="background-color:#dce8f5; color:#3a6186;">Web</span>
+            <small style="color:#a8c8e8;">Educación</small>
           </div>
           <div class="card-body">
             <h5 class="card-title">Felinux Plataforma PANCE</h5>
             <p class="card-text text-muted">Plataforma de evaluación y preparación para el examen PANCE de licenciados en medicina veterinaria.</p>
             <div class="mt-2">
-              <span class="badge bg-primary me-1">PHP</span>
-              <span class="badge bg-warning text-dark me-1">jQuery</span>
-              <span class="badge bg-secondary">MySQL</span>
+              <span class="badge me-1" style="background-color:#3a6186; color:#dce8f5;">PHP</span>
+              <span class="badge me-1" style="background-color:#9a7c2e; color:#fef3c7;">jQuery</span>
+              <span class="badge" style="background-color:#718096; color:#e2e8f0;">MySQL</span>
             </div>
           </div>
         </div>

--- a/src/app/pages/portfolio/portfolio.component.ts
+++ b/src/app/pages/portfolio/portfolio.component.ts
@@ -1,12 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   standalone: true,
   selector: 'app-portfolio',
   templateUrl: './portfolio.component.html',
 })
-export class PortfolioComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit(): void {}
-}
+export class PortfolioComponent {}


### PR DESCRIPTION
## Cambios

### Colores suavizados
Reemplaza colores Bootstrap saturados en los headers de las cards:

| Categoría | Antes | Después |
|-----------|-------|---------|
| Mainframe | g-dark (#212529) | Gris pizarra #4a5568 |
| Web | g-primary (#0d6efd) | Azul acero #3a6186 |
| Financiero | g-success (#198754) | Verde musgo #3d7a5e |
| Oracle badge | g-danger | Rojo oscuro #8b3a3a |
| jQuery badge | g-warning | Ámbar oscuro #9a7c2e |

### Traducción
- Filtro All → Todos`n
### Limpieza de código
- Elimina OnInit e 
gOnInit() vacío del componente