### PR TITLE
refactor: replace deprecated NgFor with built-in @for control flow

### DIFF
--- a/src/app/pages/portfolio/portfolio.component.html
+++ b/src/app/pages/portfolio/portfolio.component.html
@@ -20,28 +20,32 @@
 
     <div class="row portfolio-grid" data-aos="fade-up" data-aos-delay="200">
 
-      <div *ngFor="let item of filteredItems" class="col-lg-4 col-md-6 portfolio-item mb-4">
-        <div class="card h-100 shadow-sm border-0">
-          <div class="card-header d-flex justify-content-between align-items-center"
-               [style.background-color]="getHeaderStyle(item.tipo).bg"
-               [style.color]="getHeaderStyle(item.tipo).text">
-            <span class="badge"
-                  [style.background-color]="getHeaderStyle(item.tipo).bg"
-                  [style.color]="getHeaderStyle(item.tipo).text"
-                  style="opacity:0.8;">{{ item.tipo }}</span>
-            <small [style.color]="getHeaderStyle(item.tipo).text" style="opacity:0.7;">{{ item.subtipo }}</small>
-          </div>
-          <div class="card-body">
-            <h5 class="card-title">{{ item.titulo }}</h5>
-            <p class="card-text text-muted">{{ item.descripcion }}</p>
-            <div class="mt-2">
-              <span *ngFor="let tech of item.tecnologias" class="badge me-1"
-                    [style.background-color]="tech.color"
-                    [style.color]="tech.textColor">{{ tech.nombre }}</span>
+      @for (item of filteredItems; track item.titulo) {
+        <div class="col-lg-4 col-md-6 portfolio-item mb-4">
+          <div class="card h-100 shadow-sm border-0">
+            <div class="card-header d-flex justify-content-between align-items-center"
+                 [style.background-color]="getHeaderStyle(item.tipo).bg"
+                 [style.color]="getHeaderStyle(item.tipo).text">
+              <span class="badge"
+                    [style.background-color]="getHeaderStyle(item.tipo).bg"
+                    [style.color]="getHeaderStyle(item.tipo).text"
+                    style="opacity:0.8;">{{ item.tipo }}</span>
+              <small [style.color]="getHeaderStyle(item.tipo).text" style="opacity:0.7;">{{ item.subtipo }}</small>
+            </div>
+            <div class="card-body">
+              <h5 class="card-title">{{ item.titulo }}</h5>
+              <p class="card-text text-muted">{{ item.descripcion }}</p>
+              <div class="mt-2">
+                @for (tech of item.tecnologias; track tech.nombre) {
+                  <span class="badge me-1"
+                        [style.background-color]="tech.color"
+                        [style.color]="tech.textColor">{{ tech.nombre }}</span>
+                }
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      }
 
     </div>
 

--- a/src/app/pages/portfolio/portfolio.component.ts
+++ b/src/app/pages/portfolio/portfolio.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { NgFor } from '@angular/common';
 import { PortfolioService } from '../../services/portfolio.service';
 import { PortfolioItem } from '../../interfaces/portfolio.interface';
 
@@ -7,12 +6,12 @@ import { PortfolioItem } from '../../interfaces/portfolio.interface';
   standalone: true,
   selector: 'app-portfolio',
   templateUrl: './portfolio.component.html',
-  imports: [NgFor],
+  imports: [],
 })
 export class PortfolioComponent {
   activeFilter = '*';
 
-  private headerStyles: Record<string, { bg: string; text: string }> = {
+  private readonly headerStyles: Record<string, { bg: string; text: string }> = {
     Mainframe: { bg: '#4a5568', text: '#e2e8f0' },
     Web: { bg: '#3a6186', text: '#dce8f5' },
     Financiero: { bg: '#3d7a5e', text: '#d8f0e4' },

--- a/src/app/pages/references/references.component.html
+++ b/src/app/pages/references/references.component.html
@@ -8,22 +8,23 @@
 
     <div class="row">
 
-      <div *ngFor="let ref of _references.references.referencias; let i = index"
-           class="col-lg-4 col-md-6 d-flex align-items-stretch"
-           data-aos="zoom-in"
-           [attr.data-aos-delay]="(i + 1) * 100">
-        <div class="card">
-          <div class="card-body d-flex flex-column">
-            <h5 class="card-title">{{ ref.nombre }}</h5>
-            <h6 class="card-subtitle mb-2 text-muted">{{ ref.cargo }} &mdash; {{ ref.empresa }}</h6>
-            <p class="card-text flex-grow-1">
-              <em class="bx bxs-quote-alt-left quote-icon-left"></em>
-              {{ ref.testimonio }}
-              <em class="bx bxs-quote-alt-right quote-icon-right"></em>
-            </p>
+      @for (ref of _references.references.referencias; track ref.nombre; let i = $index) {
+        <div class="col-lg-4 col-md-6 d-flex align-items-stretch"
+             data-aos="zoom-in"
+             [attr.data-aos-delay]="(i + 1) * 100">
+          <div class="card">
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title">{{ ref.nombre }}</h5>
+              <h6 class="card-subtitle mb-2 text-muted">{{ ref.cargo }} &mdash; {{ ref.empresa }}</h6>
+              <p class="card-text flex-grow-1">
+                <em class="bx bxs-quote-alt-left quote-icon-left"></em>
+                {{ ref.testimonio }}
+                <em class="bx bxs-quote-alt-right quote-icon-right"></em>
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+      }
 
     </div>
 

--- a/src/app/pages/references/references.component.ts
+++ b/src/app/pages/references/references.component.ts
@@ -1,12 +1,11 @@
 import { Component } from '@angular/core';
-import { NgFor } from '@angular/common';
 import { ReferencesService } from '../../services/references.service';
 
 @Component({
   standalone: true,
   selector: 'app-references',
   templateUrl: './references.component.html',
-  imports: [NgFor],
+  imports: [],
 })
 export class ReferencesComponent {
   constructor(public _references: ReferencesService) {}


### PR DESCRIPTION
## Summary
- Remove `NgFor` import (deprecated in Angular 17+) from `PortfolioComponent` and `ReferencesComponent`
- Replace `*ngFor` directive with built-in `@for` control flow syntax
- Mark `headerStyles` as `readonly`

## Test plan
- [ ] Portfolio cards render correctly with all 9 items
- [ ] Portfolio filters (Todos / Mainframe / Financiero / Web) work
- [ ] References section renders 3 cards from Firebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)