### PR TITLE
fix: add keyboard accessibility to portfolio filter buttons

### DIFF
--- a/src/app/pages/portfolio/portfolio.component.html
+++ b/src/app/pages/portfolio/portfolio.component.html
@@ -10,10 +10,10 @@
     <div class="row">
       <div class="col-lg-12 d-flex justify-content-center" data-aos="fade-up" data-aos-delay="100">
         <ul id="portfolio-flters">
-          <li [class.filter-active]="activeFilter === '*'" (click)="setFilter('*')">Todos</li>
-          <li [class.filter-active]="activeFilter === 'filter-app'" (click)="setFilter('filter-app')">Mainframe</li>
-          <li [class.filter-active]="activeFilter === 'filter-card'" (click)="setFilter('filter-card')">Financiero</li>
-          <li [class.filter-active]="activeFilter === 'filter-web'" (click)="setFilter('filter-web')">Web</li>
+          <li tabindex="0" [class.filter-active]="activeFilter === '*'" (click)="setFilter('*')" (keydown.enter)="setFilter('*')" (keydown.space)="setFilter('*')">Todos</li>
+          <li tabindex="0" [class.filter-active]="activeFilter === 'filter-app'" (click)="setFilter('filter-app')" (keydown.enter)="setFilter('filter-app')" (keydown.space)="setFilter('filter-app')">Mainframe</li>
+          <li tabindex="0" [class.filter-active]="activeFilter === 'filter-card'" (click)="setFilter('filter-card')" (keydown.enter)="setFilter('filter-card')" (keydown.space)="setFilter('filter-card')">Financiero</li>
+          <li tabindex="0" [class.filter-active]="activeFilter === 'filter-web'" (click)="setFilter('filter-web')" (keydown.enter)="setFilter('filter-web')" (keydown.space)="setFilter('filter-web')">Web</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Add tabindex and keydown.enter/keydown.space handlers to <li> filter elements to satisfy WCAG keyboard navigation requirements.